### PR TITLE
Add mlm extension (https://github.com/crim-ca/mlm-extension)

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -2,6 +2,7 @@
 COMMUNITY_REPOS = [
   # org, repo name
   ['crim-ca', 'dlm-extension'],
+  ['crim-ca', 'mlm-extension'],
   ['Terradue', 'stac-extensions-disaster'],
   ['TrainingDML', 'trainingdml-ai-extension']
 ]


### PR DESCRIPTION
The MLM extension is now hosted on https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json

The previous DLM extension has been set to "deprecated" maturity and is archived: https://github.com/crim-ca/dlm-extension

The previous ML-Model extension is pending approval for deprecation as well: https://github.com/stac-extensions/ml-model/pull/16

