### PR TITLE
update invalid trainingdml-ai-extension reference

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -3,7 +3,7 @@ COMMUNITY_REPOS = [
   # org, repo name
   ['crim-ca', 'dlm-extension'],
   ['Terradue', 'stac-extensions-disaster'],
-  ['TrainingDML', 'trainingdml-ai-extension']
+  ['openrsgis', 'trainingdml-ai-extension']
 ]
 
 # Other extensions that are not on GitHub


### PR DESCRIPTION
The contents were moved to https://github.com/openrsgis/trainingdml-ai-extension, as indicated in https://github.com/TrainingDML/trainingdml-ai-extension