### PR TITLE
Update MLM reference with official location

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -2,9 +2,6 @@
 COMMUNITY_REPOS = [
   # org, repo name
   ['crim-ca', 'dlm-extension'],
-  # MLM migrated to official https://github.com/stac-extensions/mlm
-  # see details: https://github.com/orgs/stac-utils/discussions/4
-  # ['crim-ca', 'mlm-extension'],
   ['Terradue', 'stac-extensions-disaster'],
   ['openrsgis', 'trainingdml-ai-extension']
 ]

--- a/python/config.py
+++ b/python/config.py
@@ -2,7 +2,9 @@
 COMMUNITY_REPOS = [
   # org, repo name
   ['crim-ca', 'dlm-extension'],
-  ['crim-ca', 'mlm-extension'],
+  # MLM migrated to official https://github.com/stac-extensions/mlm
+  # see details: https://github.com/orgs/stac-utils/discussions/4
+  # ['crim-ca', 'mlm-extension'],
   ['Terradue', 'stac-extensions-disaster'],
   ['openrsgis', 'trainingdml-ai-extension']
 ]


### PR DESCRIPTION
Details: https://github.com/orgs/stac-utils/discussions/4#discussioncomment-10767685

Waiting on the official MLM repository to be ready and publicly available before switch.