### PR TITLE
Add Iceberg extension (portolan-sdi/stac-iceberg-extension)

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -6,7 +6,8 @@ COMMUNITY_REPOS = [
   ['openrsgis', 'trainingdml-ai-extension'],
   ['stacchain', 'merkle-tree'],
   ['IFRCGo', 'monty-stac-extension'],
-  ['cityjson', 'stac-city3d']
+  ['cityjson', 'stac-city3d'],
+  ['portolan-sdi', 'stac-iceberg-extension']
 ]
 
 # Other extensions that are not on GitHub


### PR DESCRIPTION
Adds the STAC Iceberg Extension to the community extensions list.

- **Repo:** https://github.com/portolan-sdi/stac-iceberg-extension
- **Schema:** https://portolan-sdi.github.io/stac-iceberg-extension/v1.0.0/schema.json
- **Prefix:** `iceberg`
- **Scope:** Collection
- **Maturity:** Proposal

The extension describes Apache Iceberg table metadata, enabling STAC clients to discover and connect to Iceberg tables for querying geospatial data.

Closes #63