### PR TITLE
Add Iceberg extension to community repos

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -6,7 +6,8 @@ COMMUNITY_REPOS = [
   ['openrsgis', 'trainingdml-ai-extension'],
   ['stacchain', 'merkle-tree'],
   ['IFRCGo', 'monty-stac-extension'],
-  ['cityjson', 'stac-city3d']
+  ['cityjson', 'stac-city3d'],
+  ['portolan-sdi', 'stac-iceberg-extension']
 ]
 
 # Other extensions that are not on GitHub


### PR DESCRIPTION
## Summary

- Add [`portolan-sdi/stac-iceberg-extension`](https://github.com/portolan-sdi/stac-iceberg-extension) to `COMMUNITY_REPOS` in `python/config.py`

## About the extension

The [STAC Iceberg Extension](https://github.com/portolan-sdi/stac-iceberg-extension) adds Apache Iceberg table access and versioning metadata to STAC Collections, enabling clients to discover and connect to Iceberg tables for querying geospatial data via PyIceberg, DuckDB, Spark, or BigQuery.

- **Prefix:** `iceberg`
- **Scope:** Collection
- **Maturity:** Proposal
- **Version:** [v1.0.0](https://github.com/portolan-sdi/stac-iceberg-extension/releases/tag/v1.0.0)
- **Schema:** https://portolan-sdi.github.io/stac-iceberg-extension/v1.0.0/schema.json
- **Reference implementation:** [Portolake](https://github.com/portolan-sdi/portolake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)