### PR TITLE
Add topo4d STAC extension (https://github.com/tum-rsa/topo4d)

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -6,7 +6,8 @@ COMMUNITY_REPOS = [
   ['openrsgis', 'trainingdml-ai-extension'],
   ['stacchain', 'merkle-tree'],
   ['IFRCGo', 'monty-stac-extension'],
-  ['cityjson', 'stac-city3d']
+  ['cityjson', 'stac-city3d'],
+  ['tum-rsa', 'topo4d']
 ]
 
 # Other extensions that are not on GitHub


### PR DESCRIPTION
Adding the Topographic 4D (topo4d) Extension to the community extensions list.

    Repo: https://github.com/tum-rsa/topo4d
    Schema: https://tum-rsa.github.io/topo4d/v0.2.0/schema.json
    Prefix: topo4d
    Scope: Item, Collection
    Maturity: Proposal

The extension proposes a standardized approach for handling time-dependent metadata in diverse 4D datasets (time series of 3D geographic data), enabling STAC clients to explore and connect to multi-temporal point cloud data.